### PR TITLE
update example to work against rasterio master

### DIFF
--- a/metasay/scripts/cli.py
+++ b/metasay/scripts/cli.py
@@ -4,13 +4,12 @@ import sys
 
 import click
 import rasterio
-from rasterio.rio.cli import cli
 
 from metasay import moothedata
 from metasay import __version__ as metasay_version
 
 
-@cli.command(short_help="Cowsay some dataset metadata.")
+@click.command(short_help="Cowsay some dataset metadata.")
 @click.argument(
     'inputfile',
     type=click.Path(resolve_path=True),
@@ -21,8 +20,8 @@ from metasay import __version__ as metasay_version
 @click.pass_context
 def metasay(ctx, inputfile, item):
     """Moo some dataset metadata to stdout.
-    
-    Python module: rio-metasay 
+
+    Python module: rio-metasay
     (https://github.com/sgillies/rio-plugin-example).
     """
 

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(name='rio-metasay',
       },
       entry_points="""
       [rasterio.rio_commands]
-      metasay=metasay.scripts.cli:cli
+      metasay=metasay.scripts.cli:metasay
       """      )


### PR DESCRIPTION
Using rasterio master (0.25.0), I needed to tweak this example a bit to get it working. Should work out of the box by using `click.command` and modifying the entry point.
